### PR TITLE
Reuse HttpClient

### DIFF
--- a/src/exercise1/final/BookClient/BookClient/Data/BookManager.cs
+++ b/src/exercise1/final/BookClient/BookClient/Data/BookManager.cs
@@ -11,10 +11,22 @@ namespace BookClient.Data
     {
         const string Url = "{Url from before}/api/books/";
         private string authorizationKey;
+        private static HttpClient client;
+
+        public static HttpClient GetClientInstance()
+        {
+            if (client == null)
+            {
+                client = new HttpClient();
+            }
+
+            return client;
+        }
 
         private async Task<HttpClient> GetClient()
         {
-            HttpClient client = new HttpClient();
+            HttpClient client = BookManager.GetClientInstance();
+
             if (string.IsNullOrEmpty(authorizationKey))
             {
                 authorizationKey = await client.GetStringAsync(Url + "login");


### PR DESCRIPTION
If this is going to be a learning example, please teach developer to reuse the HttpClient.
Not doing so will have a perfomance impact, because the connection to the remote server could be closed and needed to be reopend.

Some references on other tips for HttpClient http://www.spikie.be/post/2016/02/29/httpclient-in-mobile-apps.html